### PR TITLE
ECUP-184: add convert to webp effect to all image styles

### DIFF
--- a/config/sync/image.style.360x360.yml
+++ b/config/sync/image.style.360x360.yml
@@ -17,3 +17,9 @@ effects:
       width: 360
       height: 360
       crop_type: focal_point
+  3a288162-6516-42c7-a095-88855ec78360:
+    uuid: 3a288162-6516-42c7-a095-88855ec78360
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.360x360_1_5x.yml
+++ b/config/sync/image.style.360x360_1_5x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 40
+  cc1b6ebf-371b-487f-9365-3caff552556b:
+    uuid: cc1b6ebf-371b-487f-9365-3caff552556b
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.360x360_2x.yml
+++ b/config/sync/image.style.360x360_2x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 35
+  1ab3db14-6d53-459b-bdf8-b80f587f15ca:
+    uuid: 1ab3db14-6d53-459b-bdf8-b80f587f15ca
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_big_desk.yml
+++ b/config/sync/image.style.banner_big_desk.yml
@@ -17,3 +17,9 @@ effects:
       width: 1600
       height: 544
       crop_type: focal_point
+  9edc22c2-ca46-40eb-9e6e-cb474cef5524:
+    uuid: 9edc22c2-ca46-40eb-9e6e-cb474cef5524
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_desk.yml
+++ b/config/sync/image.style.banner_desk.yml
@@ -17,3 +17,9 @@ effects:
       width: 1000
       height: 400
       crop_type: focal_point
+  b042006b-0962-4f94-85a9-9f971615cc3c:
+    uuid: b042006b-0962-4f94-85a9-9f971615cc3c
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_middesk.yml
+++ b/config/sync/image.style.banner_middesk.yml
@@ -17,3 +17,9 @@ effects:
       width: 1200
       height: 448
       crop_type: focal_point
+  29cc94c9-8915-43b5-8785-14e21d290704:
+    uuid: 29cc94c9-8915-43b5-8785-14e21d290704
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_mobile.yml
+++ b/config/sync/image.style.banner_mobile.yml
@@ -17,3 +17,9 @@ effects:
       width: 400
       height: 300
       crop_type: focal_point
+  c5f14e92-264e-4456-8a8d-3547a87e12a3:
+    uuid: c5f14e92-264e-4456-8a8d-3547a87e12a3
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_mobile_1_5x.yml
+++ b/config/sync/image.style.banner_mobile_1_5x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 45
+  c8cc9993-6f49-4d20-a423-bfb473f92481:
+    uuid: c8cc9993-6f49-4d20-a423-bfb473f92481
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_mobile_2x.yml
+++ b/config/sync/image.style.banner_mobile_2x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 35
+  53f51b62-eb66-41f3-8b30-65ffe88599da:
+    uuid: 53f51b62-eb66-41f3-8b30-65ffe88599da
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_tablet.yml
+++ b/config/sync/image.style.banner_tablet.yml
@@ -17,3 +17,9 @@ effects:
       width: 800
       height: 448
       crop_type: focal_point
+  0ee03fc4-cf4e-438d-a281-8d408dabe4b6:
+    uuid: 0ee03fc4-cf4e-438d-a281-8d408dabe4b6
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_tablet_1_5x.yml
+++ b/config/sync/image.style.banner_tablet_1_5x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 35
+  1c9aeaa1-601a-41ce-97a6-c61cfed58fc6:
+    uuid: 1c9aeaa1-601a-41ce-97a6-c61cfed58fc6
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.banner_tablet_2x.yml
+++ b/config/sync/image.style.banner_tablet_2x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 30
+  6ebfb2ab-2e15-4c8b-bbb6-3693431b7f33:
+    uuid: 6ebfb2ab-2e15-4c8b-bbb6-3693431b7f33
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.full_non_crop.yml
+++ b/config/sync/image.style.full_non_crop.yml
@@ -15,3 +15,9 @@ effects:
       width: 1200
       height: null
       upscale: true
+  0b3e379c-a70c-4c9c-ae56-f7bd465e3cb3:
+    uuid: 0b3e379c-a70c-4c9c-ae56-f7bd465e3cb3
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.large.yml
+++ b/config/sync/image.style.large.yml
@@ -15,3 +15,9 @@ effects:
       width: 480
       height: 480
       upscale: false
+  601bc2a4-01d9-443a-b79c-30d0155e0612:
+    uuid: 601bc2a4-01d9-443a-b79c-30d0155e0612
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.large_non_crop.yml
+++ b/config/sync/image.style.large_non_crop.yml
@@ -15,3 +15,9 @@ effects:
       width: 800
       height: null
       upscale: true
+  65705afd-da31-4817-abbe-ec3c6af7b076:
+    uuid: 65705afd-da31-4817-abbe-ec3c6af7b076
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.large_thumbnail.yml
+++ b/config/sync/image.style.large_thumbnail.yml
@@ -17,3 +17,9 @@ effects:
       width: 240
       height: 200
       crop_type: focal_point
+  5ac71938-1029-4480-a866-50b1685d9433:
+    uuid: 5ac71938-1029-4480-a866-50b1685d9433
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.large_thumbnail_1_5x.yml
+++ b/config/sync/image.style.large_thumbnail_1_5x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 40
+  a2d6a03e-b17d-4d24-bf62-c8c7fa173b02:
+    uuid: a2d6a03e-b17d-4d24-bf62-c8c7fa173b02
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.large_thumbnail_2x.yml
+++ b/config/sync/image.style.large_thumbnail_2x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 35
+  65c85737-db8e-4064-b8e5-e3bfe953a83f:
+    uuid: 65c85737-db8e-4064-b8e5-e3bfe953a83f
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.linkit_result_thumbnail.yml
+++ b/config/sync/image.style.linkit_result_thumbnail.yml
@@ -15,3 +15,9 @@ effects:
       width: 50
       height: 50
       anchor: center-center
+  b711c906-92e8-4a40-accd-52513c1743a9:
+    uuid: b711c906-92e8-4a40-accd-52513c1743a9
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.max_1300x1300.yml
+++ b/config/sync/image.style.max_1300x1300.yml
@@ -18,3 +18,9 @@ effects:
       width: 1300
       height: 1300
       upscale: false
+  b198fd31-b277-4abc-9a52-7e246f5447ec:
+    uuid: b198fd31-b277-4abc-9a52-7e246f5447ec
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.max_2600x2600.yml
+++ b/config/sync/image.style.max_2600x2600.yml
@@ -13,8 +13,14 @@ effects:
   9b311dd1-0351-45a1-9500-cd069e4670cb:
     uuid: 9b311dd1-0351-45a1-9500-cd069e4670cb
     id: image_scale
-    weight: 3
+    weight: -10
     data:
       width: 2600
       height: 2600
       upscale: false
+  a580dfdf-bf28-40c2-8162-275504efdd79:
+    uuid: a580dfdf-bf28-40c2-8162-275504efdd79
+    id: image_convert
+    weight: -9
+    data:
+      extension: webp

--- a/config/sync/image.style.max_325x325.yml
+++ b/config/sync/image.style.max_325x325.yml
@@ -18,3 +18,9 @@ effects:
       width: 325
       height: 325
       upscale: false
+  d3facf9c-fe19-40ca-bf7b-d896e392c917:
+    uuid: d3facf9c-fe19-40ca-bf7b-d896e392c917
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.max_650x650.yml
+++ b/config/sync/image.style.max_650x650.yml
@@ -18,3 +18,9 @@ effects:
       width: 650
       height: 650
       upscale: false
+  270afefd-488a-421a-92be-2d0d7b701c79:
+    uuid: 270afefd-488a-421a-92be-2d0d7b701c79
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.maxwidth_1200.yml
+++ b/config/sync/image.style.maxwidth_1200.yml
@@ -15,3 +15,9 @@ effects:
       width: 1200
       height: null
       upscale: true
+  382b88b1-ca3a-4167-9123-1cbf14b24c5f:
+    uuid: 382b88b1-ca3a-4167-9123-1cbf14b24c5f
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.media_library.yml
+++ b/config/sync/image.style.media_library.yml
@@ -18,3 +18,9 @@ effects:
       width: 220
       height: 220
       upscale: false
+  0d09ab87-7942-4a81-ad99-d03a423babe1:
+    uuid: 0d09ab87-7942-4a81-ad99-d03a423babe1
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.medium.yml
+++ b/config/sync/image.style.medium.yml
@@ -15,3 +15,9 @@ effects:
       width: 220
       height: 220
       upscale: false
+  fb83fae4-8691-43a7-9edb-7c190bc732bb:
+    uuid: fb83fae4-8691-43a7-9edb-7c190bc732bb
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.medium_non_crop.yml
+++ b/config/sync/image.style.medium_non_crop.yml
@@ -15,3 +15,9 @@ effects:
       width: 480
       height: null
       upscale: true
+  cc03cf41-79c5-4ad6-b969-0bfb717b3940:
+    uuid: cc03cf41-79c5-4ad6-b969-0bfb717b3940
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.medium_non_crop_1_5x.yml
+++ b/config/sync/image.style.medium_non_crop_1_5x.yml
@@ -23,3 +23,9 @@ effects:
     weight: 2
     data:
       quality: 35
+  048d1bbf-e36e-4dfe-9f59-c09c08ecfafb:
+    uuid: 048d1bbf-e36e-4dfe-9f59-c09c08ecfafb
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.medium_non_crop_2x.yml
+++ b/config/sync/image.style.medium_non_crop_2x.yml
@@ -23,3 +23,9 @@ effects:
     weight: 2
     data:
       quality: 30
+  e5766505-027f-41f4-ae68-307065d6e862:
+    uuid: e5766505-027f-41f4-ae68-307065d6e862
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.paragraph_preview.yml
+++ b/config/sync/image.style.paragraph_preview.yml
@@ -15,3 +15,9 @@ effects:
       width: 50
       height: 30
       anchor: center-center
+  b3b6b091-5e3e-4cd1-80e5-73a90f3a1b7d:
+    uuid: b3b6b091-5e3e-4cd1-80e5-73a90f3a1b7d
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.small_non_crop.yml
+++ b/config/sync/image.style.small_non_crop.yml
@@ -15,3 +15,9 @@ effects:
       width: 280
       height: null
       upscale: false
+  5b35bd20-2f00-4203-befe-07cb534a1350:
+    uuid: 5b35bd20-2f00-4203-befe-07cb534a1350
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.small_non_crop_1_5x.yml
+++ b/config/sync/image.style.small_non_crop_1_5x.yml
@@ -23,3 +23,9 @@ effects:
     weight: 2
     data:
       quality: 45
+  e51f22d7-47a3-4fef-bd96-422309eed806:
+    uuid: e51f22d7-47a3-4fef-bd96-422309eed806
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.small_non_crop_2x.yml
+++ b/config/sync/image.style.small_non_crop_2x.yml
@@ -23,3 +23,9 @@ effects:
     weight: 2
     data:
       quality: 40
+  5a3c9bc7-7be2-40f2-b00a-9ede6c382569:
+    uuid: 5a3c9bc7-7be2-40f2-b00a-9ede6c382569
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.thumbnail.yml
+++ b/config/sync/image.style.thumbnail.yml
@@ -15,3 +15,9 @@ effects:
       width: 100
       height: 100
       upscale: false
+  c279f1dd-eb65-4861-9a45-603e88443f6b:
+    uuid: c279f1dd-eb65-4861-9a45-603e88443f6b
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.thumbnail_cropped.yml
+++ b/config/sync/image.style.thumbnail_cropped.yml
@@ -17,3 +17,9 @@ effects:
       width: 96
       height: 96
       crop_type: focal_point
+  9a8065aa-bd93-4f98-9868-7c389ee49317:
+    uuid: 9a8065aa-bd93-4f98-9868-7c389ee49317
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.thumbnail_cropped_1_5x.yml
+++ b/config/sync/image.style.thumbnail_cropped_1_5x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 45
+  00c9d45c-0354-41d0-afa6-b736d13bf888:
+    uuid: 00c9d45c-0354-41d0-afa6-b736d13bf888
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.thumbnail_cropped_2x.yml
+++ b/config/sync/image.style.thumbnail_cropped_2x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 40
+  b6540d71-133e-4371-a6d0-645b68702fca:
+    uuid: b6540d71-133e-4371-a6d0-645b68702fca
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.views_card.yml
+++ b/config/sync/image.style.views_card.yml
@@ -17,3 +17,9 @@ effects:
       width: 400
       height: 300
       crop_type: focal_point
+  2dbb2f8c-6adb-4fb6-8819-f7bcd22ca0d7:
+    uuid: 2dbb2f8c-6adb-4fb6-8819-f7bcd22ca0d7
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/sync/image.style.views_card_1_5x.yml
+++ b/config/sync/image.style.views_card_1_5x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 40
+  4332f4c9-ddf8-40ef-8c37-14ca5e48dd0b:
+    uuid: 4332f4c9-ddf8-40ef-8c37-14ca5e48dd0b
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.views_card_2x.yml
+++ b/config/sync/image.style.views_card_2x.yml
@@ -24,3 +24,9 @@ effects:
     weight: 2
     data:
       quality: 35
+  caf828f5-6ecb-444f-bb46-b0f2f8b6466f:
+    uuid: caf828f5-6ecb-444f-bb46-b0f2f8b6466f
+    id: image_convert
+    weight: 3
+    data:
+      extension: webp

--- a/config/sync/image.style.wide.yml
+++ b/config/sync/image.style.wide.yml
@@ -15,3 +15,9 @@ effects:
       width: 1090
       height: null
       upscale: false
+  0293ce47-c993-40ed-b760-304ccee40e21:
+    uuid: 0293ce47-c993-40ed-b760-304ccee40e21
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp


### PR DESCRIPTION
All 41 image styles were updated to include the effect to convert the image into webp format.  Webp effect was weighted to be the last effect processed.