### PR TITLE
ECUP-286: Add Claude Text field to Basic Page

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -15,8 +16,6 @@ dependencies:
     - media_library
     - path
     - text
-_core:
-  default_config_hash: AiIN5NmdeLPo4TB4twM4DqmFPIh2MoiDLb-mjYmVdHE
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -24,7 +23,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 9
@@ -35,6 +34,14 @@ content:
       allowed_formats:
         hide_help: '1'
         hide_guidelines: '1'
+  field_claude_text:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_image:
     type: media_library_widget
     weight: 0
@@ -44,7 +51,7 @@ content:
     third_party_settings: {  }
   field_meta_description:
     type: string_textarea
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -52,7 +59,7 @@ content:
     third_party_settings: {  }
   field_paragraphs:
     type: layout_paragraphs
-    weight: 4
+    weight: 5
     region: content
     settings:
       view_mode: default
@@ -64,7 +71,7 @@ content:
     third_party_settings: {  }
   field_search_keywords:
     type: string_textfield
-    weight: 5
+    weight: 6
     region: content
     settings:
       size: 60
@@ -72,13 +79,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -150,6 +151,32 @@ third_party_settings:
             weight: 0
             additional: {  }
         third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+          context_mapping: {  }
+        components:
+          ee11d4f6-6b3a-42d7-8b8b-e8cecfa48a85:
+            uuid: ee11d4f6-6b3a-42d7-8b8b-e8cecfa48a85
+            region: content
+            configuration:
+              id: 'field_block:node:page:field_claude_text'
+              label: 'Claude Text'
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: string
+                label: hidden
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+        third_party_settings: {  }
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -177,6 +204,7 @@ content:
     region: content
 hidden:
   body: true
+  field_claude_text: true
   field_image: true
   field_paragraphs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -18,8 +19,6 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-_core:
-  default_config_hash: QY84XCJelpMQMf9_s_YDi4EogUf7Nfk4AG3w7x1M2wI
 id: node.page.teaser
 targetEntityType: node
 bundle: page
@@ -37,6 +36,14 @@ content:
       trim_length: 600
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_claude_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_image: true

--- a/config/sync/field.field.node.page.field_claude_text.yml
+++ b/config/sync/field.field.node.page.field_claude_text.yml
@@ -1,0 +1,19 @@
+uuid: 1be93f16-4c28-4d99-badb-b300eda0db88
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_claude_text
+    - node.type.page
+id: node.page.field_claude_text
+field_name: field_claude_text
+entity_type: node
+bundle: page
+label: 'Claude Text'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_claude_text.yml
+++ b/config/sync/field.storage.node.field_claude_text.yml
@@ -1,0 +1,21 @@
+uuid: 17041e8c-3c7e-4b84-824b-44f84b941622
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_claude_text
+field_name: field_claude_text
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Summary

- Adds a new required plain text field (`field_claude_text`, label: **Claude Text**) to the Basic Page content type
- Placed just below the Title field in the node edit form (weight 2)
- Added as a new Layout Builder section at the bottom of the Default display
- Added last in the Teaser display (weight 1, after Body)

## Config changes

| File | Change |
|------|--------|
| `field.storage.node.field_claude_text.yml` | New field storage (string, max 255) |
| `field.field.node.page.field_claude_text.yml` | Field instance on Basic Page, required |
| `core.entity_form_display.node.page.default.yml` | Added at weight 2 below Title; bumped other weights |
| `core.entity_view_display.node.page.default.yml` | New Layout Builder one-col section at bottom |
| `core.entity_view_display.node.page.teaser.yml` | Added last (weight 1, after Body) |

## Decisions

- Used `string` type (plain text, 255 char max) per the ticket's "plain text" requirement
- The default Layout Builder display uses a new `layout_onecol` section appended after the Widgets/Paragraphs section, which matches the existing section pattern in the display
- Field renders with label hidden in both the teaser and Layout Builder contexts, consistent with how other content fields are displayed

Closes https://ecitizen.atlassian.net/browse/ECUP-286

🤖 Generated with [Claude Code](https://claude.com/claude-code)