### PR TITLE
ECUP-287: Add Claude Text field to Basic Page

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -24,7 +25,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 9
@@ -35,6 +36,14 @@ content:
       allowed_formats:
         hide_help: '1'
         hide_guidelines: '1'
+  field_claude_text:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_image:
     type: media_library_widget
     weight: 0
@@ -44,7 +53,7 @@ content:
     third_party_settings: {  }
   field_meta_description:
     type: string_textarea
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -52,7 +61,7 @@ content:
     third_party_settings: {  }
   field_paragraphs:
     type: layout_paragraphs
-    weight: 4
+    weight: 5
     region: content
     settings:
       view_mode: default
@@ -64,7 +73,7 @@ content:
     third_party_settings: {  }
   field_search_keywords:
     type: string_textfield
-    weight: 5
+    weight: 6
     region: content
     settings:
       size: 60
@@ -72,13 +81,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -150,6 +151,32 @@ third_party_settings:
             weight: 0
             additional: {  }
         third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+          context_mapping: {  }
+        components:
+          57c7dd83-ed5b-4933-b645-96ded203c08d:
+            uuid: 57c7dd83-ed5b-4933-b645-96ded203c08d
+            region: content
+            configuration:
+              id: 'field_block:node:page:field_claude_text'
+              label: 'Claude Text'
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: string
+                label: hidden
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+        third_party_settings: {  }
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -177,6 +204,7 @@ content:
     region: content
 hidden:
   body: true
+  field_claude_text: true
   field_image: true
   field_paragraphs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -37,6 +38,14 @@ content:
       trim_length: 600
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_claude_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_image: true

--- a/config/sync/field.field.node.page.field_claude_text.yml
+++ b/config/sync/field.field.node.page.field_claude_text.yml
@@ -1,0 +1,19 @@
+uuid: aeb9d5a8-e709-4d7f-89cd-14cdce80b30d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_claude_text
+    - node.type.page
+id: node.page.field_claude_text
+field_name: field_claude_text
+entity_type: node
+bundle: page
+label: 'Claude Text'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_claude_text.yml
+++ b/config/sync/field.storage.node.field_claude_text.yml
@@ -1,0 +1,21 @@
+uuid: f96221cd-7ba0-455c-98b0-db9ffaee07c8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_claude_text
+field_name: field_claude_text
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Summary

- Added a new required plain text (`string`) field `field_claude_text` ("Claude Text") to the Basic Page content type
- Placed it just below the title (weight 2) in the node edit form display
- Added it in a new one-column Layout Builder section at the bottom of the default page display
- Placed it last (weight 1, after body) in the teaser view display

## Decisions

- Used `string` type (single-line, 255 chars) for "plain text field" — if multi-line was intended, `string_long` would be used instead
- The new Layout Builder section uses `layout_onecol` to match the pattern of the other standalone sections (hero and paragraphs sections)
- Field label is hidden in both teaser and Layout Builder default displays, consistent with other fields

## Test plan

- [ ] Edit a Basic Page node and confirm "Claude Text" appears below the Title field and is required
- [ ] Confirm the field value renders in a new section at the bottom of the default page layout
- [ ] Confirm the field value renders last in teaser view

🤖 Generated with [Claude Code](https://claude.com/claude-code)