### PR TITLE
ECUP-288: Add Claude Text field to Basic Page content type

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -15,8 +16,6 @@ dependencies:
     - media_library
     - path
     - text
-_core:
-  default_config_hash: AiIN5NmdeLPo4TB4twM4DqmFPIh2MoiDLb-mjYmVdHE
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -24,7 +23,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 9
@@ -35,6 +34,14 @@ content:
       allowed_formats:
         hide_help: '1'
         hide_guidelines: '1'
+  field_claude_text:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_image:
     type: media_library_widget
     weight: 0
@@ -44,7 +51,7 @@ content:
     third_party_settings: {  }
   field_meta_description:
     type: string_textarea
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -52,7 +59,7 @@ content:
     third_party_settings: {  }
   field_paragraphs:
     type: layout_paragraphs
-    weight: 4
+    weight: 5
     region: content
     settings:
       view_mode: default
@@ -64,7 +71,7 @@ content:
     third_party_settings: {  }
   field_search_keywords:
     type: string_textfield
-    weight: 5
+    weight: 6
     region: content
     settings:
       size: 60
@@ -72,13 +79,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -150,6 +151,32 @@ third_party_settings:
             weight: 0
             additional: {  }
         third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+          context_mapping: {  }
+        components:
+          40f42331-1f97-46d8-882b-0214a6595cab:
+            uuid: 40f42331-1f97-46d8-882b-0214a6595cab
+            region: content
+            configuration:
+              id: 'field_block:node:page:field_claude_text'
+              label: 'Claude Text'
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: string
+                label: hidden
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+        third_party_settings: {  }
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -177,6 +204,7 @@ content:
     region: content
 hidden:
   body: true
+  field_claude_text: true
   field_image: true
   field_paragraphs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -18,8 +19,6 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-_core:
-  default_config_hash: QY84XCJelpMQMf9_s_YDi4EogUf7Nfk4AG3w7x1M2wI
 id: node.page.teaser
 targetEntityType: node
 bundle: page
@@ -37,6 +36,14 @@ content:
       trim_length: 600
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_claude_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 102
     region: content
 hidden:
   field_image: true

--- a/config/sync/field.field.node.page.field_claude_text.yml
+++ b/config/sync/field.field.node.page.field_claude_text.yml
@@ -1,0 +1,19 @@
+uuid: e079655a-de03-48cd-b4ad-bef58d0afe0a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_claude_text
+    - node.type.page
+id: node.page.field_claude_text
+field_name: field_claude_text
+entity_type: node
+bundle: page
+label: 'Claude Text'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_claude_text.yml
+++ b/config/sync/field.storage.node.field_claude_text.yml
@@ -1,0 +1,21 @@
+uuid: c19ec07e-96ba-4912-b033-0d0067676bc9
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_claude_text
+field_name: field_claude_text
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Summary

- Adds a new required plain text field (`field_claude_text`, labeled "Claude Text") to the Basic Page content type
- Places the field just below the Title in the node edit form (weight 2)
- Places the field in a new one-column section at the bottom of the default Layout Builder display
- Places the field last (weight 102) in the teaser view display

## What changed

**New config files:**
- `field.storage.node.field_claude_text.yml` — field storage definition (`string` type, 255 char max, cardinality 1)
- `field.field.node.page.field_claude_text.yml` — field instance on Basic Page, required

**Updated config files:**
- `core.entity_form_display.node.page.default.yml` — inserts field at weight 2 (after title at weight 1); existing fields shifted down by 1
- `core.entity_view_display.node.page.default.yml` — new 4th Layout Builder section (one-column) at the bottom containing the field
- `core.entity_view_display.node.page.teaser.yml` — field added at weight 102 (after addtoany at 101), displayed with hidden label

## Decisions made

- Used `string` type (plain text, 255 chars) as specified — not `string_long` or `text_with_summary`
- Field is required as specified
- In the Layout Builder default display, added a new one-column section rather than placing the field in an existing section, per ticket ("new section at the bottom")
- Teaser display uses `string` formatter with hidden label to match the plain text nature of the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)