### PR TITLE
ECUP-294: Add Claude Text field to Basic Page

### DIFF
--- a/EC-INSTALL.md
+++ b/EC-INSTALL.md
@@ -9,7 +9,7 @@ Reviewed by Adam, 2025-11-19
 - **BRANCH:** main
 - **HOSTING:** [Pantheon Dashboard](https://dashboard.pantheon.io/sites/b043b678-2567-403a-aafc-947c7d9a76de#dev/code)
 )
-- **CIRCLE CI:** [Logs](https://app.circleci.com/pipelines/github/electriccitizen/ec-upstream)
+- **CIRCLE CI:** [Logs](https://app.circleci.com/pipelines/github/electriccitizen/ec-upstream) 
 
 ## Requirements and platform docs
 

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -24,7 +25,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 9
@@ -35,6 +36,14 @@ content:
       allowed_formats:
         hide_help: '1'
         hide_guidelines: '1'
+  field_claude_text:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_image:
     type: media_library_widget
     weight: 0
@@ -44,7 +53,7 @@ content:
     third_party_settings: {  }
   field_meta_description:
     type: string_textarea
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -52,7 +61,7 @@ content:
     third_party_settings: {  }
   field_paragraphs:
     type: layout_paragraphs
-    weight: 4
+    weight: 5
     region: content
     settings:
       view_mode: default
@@ -64,7 +73,7 @@ content:
     third_party_settings: {  }
   field_search_keywords:
     type: string_textfield
-    weight: 5
+    weight: 6
     region: content
     settings:
       size: 60
@@ -72,13 +81,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -150,6 +151,32 @@ third_party_settings:
             weight: 0
             additional: {  }
         third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+          context_mapping: {  }
+        components:
+          2c1ee658-d299-4cd5-89dc-421e76ebb637:
+            uuid: 2c1ee658-d299-4cd5-89dc-421e76ebb637
+            region: content
+            configuration:
+              id: 'field_block:node:page:field_claude_text'
+              label: 'Claude Text'
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: string
+                label: hidden
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+        third_party_settings: {  }
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -177,6 +204,7 @@ content:
     region: content
 hidden:
   body: true
+  field_claude_text: true
   field_image: true
   field_paragraphs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
+    - field.field.node.page.field_claude_text
     - field.field.node.page.field_image
     - field.field.node.page.field_meta_description
     - field.field.node.page.field_paragraphs
@@ -37,6 +38,14 @@ content:
       trim_length: 600
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_claude_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 102
     region: content
 hidden:
   field_image: true

--- a/config/sync/field.field.node.page.field_claude_text.yml
+++ b/config/sync/field.field.node.page.field_claude_text.yml
@@ -1,0 +1,19 @@
+uuid: 13a151a4-4a87-44a1-9b74-1cb43c34092c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_claude_text
+    - node.type.page
+id: node.page.field_claude_text
+field_name: field_claude_text
+entity_type: node
+bundle: page
+label: 'Claude Text'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_claude_text.yml
+++ b/config/sync/field.storage.node.field_claude_text.yml
@@ -1,0 +1,21 @@
+uuid: df5748d3-bb92-455d-9072-cd2ece77727d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_claude_text
+field_name: field_claude_text
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Summary

- Added a new required plain text (`string`) field `field_claude_text` (label: **Claude Text**) to the Basic Page content type
- Placed the field immediately below the title (weight 2) in the node edit form
- Added a new one-column Layout Builder section at the bottom of the default display with the field rendered as plain text, label hidden
- Added the field as the last item (weight 102) in the Teaser view display

## Config files changed

- `field.storage.node.field_claude_text.yml` — new field storage (type: `string`, single-value, required)
- `field.field.node.page.field_claude_text.yml` — field instance on Basic Page
- `core.entity_form_display.node.page.default.yml` — field added at weight 2; existing fields shifted down
- `core.entity_view_display.node.page.default.yml` — new Layout Builder section (one-column) appended at the bottom
- `core.entity_view_display.node.page.teaser.yml` — field added at weight 102 (last)

## Decisions

- Used `string` (plain text, 255 char max) rather than `string_long` — the ticket specified "plain text field" without indicating long/multi-line content
- Label hidden in both Layout Builder and Teaser displays; adjust if a visible label is needed
- New Layout Builder section uses `layout_onecol` to match the pattern of the existing paragraphs section

Jira: https://ecitizen.atlassian.net/browse/ECUP-294

🤖 Generated with [Claude Code](https://claude.com/claude-code)