### PR TITLE
Fix Gin sidebar disappearing after viewport resize (drupal.org #3580451)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,10 @@
       "drupal/core": {
       	"Media library won't allow media in two fields with the same name on nodes": "https://www.drupal.org/files/issues/2023-02-28/3345064.patch",
         "Update module can get 'stuck' with 'no releases available', https://www.drupal.org/project/drupal/issues/2920285": "https://www.drupal.org/files/issues/2920285-update-status.patch"
+      },
+      "drupal/gin": {
+        "3580451 - Sidebar disappears after viewport resize (storage-key race)": "patches/gin-3580451-sidebar-storage-key-race-condition.patch",
+        "3580451 - Restore missing .meta-sidebar__trigger CSS selectors": "patches/gin-3580451-sidebar-missing-css-selectors.patch"
       }
     },
     "composer-exit-on-patch-failure": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bdd4593330d3487b64b3654732e99bc",
+    "content-hash": "bb8293eb88a14768ccaa546b7e78eab7",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/gin-3580451-sidebar-missing-css-selectors.patch
+++ b/patches/gin-3580451-sidebar-missing-css-selectors.patch
@@ -1,0 +1,162 @@
+diff --git a/dist/css/components/sidebar.css b/dist/css/components/sidebar.css
+index f62a2882..73f8bfeb 100644
+--- a/dist/css/components/sidebar.css
++++ b/dist/css/components/sidebar.css
+@@ -63,7 +63,8 @@ body[data-meta-sidebar=closed] .layout-region-node-secondary {
+   }
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close,
++.meta-sidebar__close {
+   cursor: pointer;
+   background: transparent;
+   height: 32px;
+@@ -72,12 +73,14 @@ body[data-meta-sidebar=closed] .layout-region-node-secondary {
+ }
+ 
+ @media (prefers-reduced-motion: no-preference) {
+-  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close {
++  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close,
++  .meta-sidebar__close {
+     transition: background var(--gin-transition-fast);
+   }
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close::before {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close::before,
++.meta-sidebar__close::before {
+   content: "";
+   display: inline-block;
+   width: 100%;
+@@ -89,23 +92,30 @@ body[data-meta-sidebar=closed] .layout-region-node-secondary {
+   background-color: var(--gin-icon-color);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:hover, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:focus {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:hover, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:focus,
++.meta-sidebar__close:hover,
++.meta-sidebar__close:focus {
+   background-color: var(--gin-color-primary-light);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:hover::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:focus::before {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:hover::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close:focus::before,
++.meta-sidebar__close:hover::before,
++.meta-sidebar__close:focus::before {
+   background-color: var(--gin-color-primary);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close.is-active {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close.is-active,
++.meta-sidebar__close.is-active {
+   background-color: var(--gin-color-primary-light-hover);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close.is-active::before {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close.is-active::before,
++.meta-sidebar__close.is-active::before {
+   background-color: var(--gin-color-primary-active);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger,
++.meta-sidebar__trigger {
+   cursor: pointer;
+   background: transparent;
+   display: block;
+@@ -115,12 +125,14 @@ body[data-meta-sidebar=closed] .layout-region-node-secondary {
+ }
+ 
+ @media (prefers-reduced-motion: no-preference) {
+-  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger {
++  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger,
++  .meta-sidebar__trigger {
+     transition: background var(--gin-transition-fast);
+   }
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger::before {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger::before,
++.meta-sidebar__trigger::before {
+   display: inline-block;
+   width: 100%;
+   height: 100%;
+@@ -137,19 +149,29 @@ body[data-meta-sidebar=closed] .layout-region-node-secondary {
+   border-radius: 50%;
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:hover, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:focus, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active:hover {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:hover, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:focus, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active:hover,
++.meta-sidebar__trigger:hover,
++.meta-sidebar__trigger:focus,
++.meta-sidebar__trigger.is-active,
++.meta-sidebar__trigger.is-active:hover {
+   background-color: var(--gin-color-primary-light);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:hover::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:focus::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active:hover::before {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:hover::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger:focus::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active::before, :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active:hover::before,
++.meta-sidebar__trigger:hover::before,
++.meta-sidebar__trigger:focus::before,
++.meta-sidebar__trigger.is-active::before,
++.meta-sidebar__trigger.is-active:hover::before {
+   background-color: var(--gin-color-primary);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__trigger.is-active,
++.meta-sidebar__trigger.is-active {
+   background-color: var(--gin-bg-item-hover);
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close,
++.meta-sidebar__close {
+   z-index: 104;
+   position: absolute;
+   inset-block-start: 18px;
+@@ -157,19 +179,22 @@ body[data-meta-sidebar=closed] .layout-region-node-secondary {
+ }
+ 
+ @media (min-width: 64em) {
+-  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close {
++  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close,
++  .meta-sidebar__close {
+     display: none;
+   }
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close::before {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__close::before,
++.meta-sidebar__close::before {
+   -webkit-mask-image: url("../../media/sprite.svg#close-view");
+           mask-image: url("../../media/sprite.svg#close-view");
+   -webkit-mask-size: 16px 16px;
+           mask-size: 16px 16px;
+ }
+ 
+-:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__overlay {
++:is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__overlay,
++.meta-sidebar__overlay {
+   z-index: 102;
+   position: fixed;
+   inset-block-start: 0;
+@@ -181,13 +206,15 @@ body[data-meta-sidebar=closed] .layout-region-node-secondary {
+   background: var(--gin-bg-layer2);
+ }
+ 
+-body[data-meta-sidebar=open] :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__overlay {
++body[data-meta-sidebar=open] :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__overlay,
++body[data-meta-sidebar=open] .meta-sidebar__overlay {
+   opacity: .9;
+   visibility: visible;
+ }
+ 
+ @media (min-width: 64em) {
+-  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__overlay {
++  :is(#extra-specificity-hack, [data-drupal-admin-styles]) .meta-sidebar__overlay,
++  .meta-sidebar__overlay {
+     display: none;
+   }
+ }

--- a/patches/gin-3580451-sidebar-storage-key-race-condition.patch
+++ b/patches/gin-3580451-sidebar-storage-key-race-condition.patch
@@ -1,0 +1,77 @@
+diff --git a/dist/js/sidebar.js b/dist/js/sidebar.js
+index 3c6a7ff1..1c94b829 100644
+--- a/dist/js/sidebar.js
++++ b/dist/js/sidebar.js
+@@ -28,16 +28,16 @@
+           Drupal.ginStickyFormActions?.hideMoreActions()) : (Drupal.ginSidebar.showSidebar(), 
+           Drupal.ginStickyFormActions?.hideMoreActions());
+         },
+-        showSidebar: () => {
+-          const chooseStorage = window.innerWidth < 1024 ? "Drupal.gin.sidebarExpanded.mobile" : storageDesktop, hideLabel = Drupal.t("Hide sidebar panel"), sidebarTrigger = document.querySelector(".meta-sidebar__trigger");
++        showSidebar: function() {
++          const chooseStorage = (arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : window.innerWidth) < 1024 ? "Drupal.gin.sidebarExpanded.mobile" : storageDesktop, hideLabel = Drupal.t("Hide sidebar panel"), sidebarTrigger = document.querySelector(".meta-sidebar__trigger");
+           null !== sidebarTrigger && (sidebarTrigger.querySelector("span").innerHTML = hideLabel, 
+           sidebarTrigger.setAttribute("title", hideLabel), sidebarTrigger.nextSibling && (sidebarTrigger.nextSibling.innerHTML = hideLabel), 
+           sidebarTrigger.setAttribute("aria-expanded", "true"), sidebarTrigger.classList.add("is-active"), 
+           document.body.setAttribute("data-meta-sidebar", "open"), localStorage.setItem(chooseStorage, "true"), 
+           window.innerWidth < 1280 && (Drupal.ginCoreNavigation?.collapseToolbar(), "vertical" === toolbarVariant ? Drupal.ginToolbar.collapseToolbar() : "new" === toolbarVariant && Drupal.behaviors.ginNavigation?.collapseSidebar()));
+         },
+-        collapseSidebar: () => {
+-          const chooseStorage = window.innerWidth < 1024 ? "Drupal.gin.sidebarExpanded.mobile" : storageDesktop, showLabel = Drupal.t("Show sidebar panel"), sidebarTrigger = document.querySelector(".meta-sidebar__trigger");
++        collapseSidebar: function() {
++          const chooseStorage = (arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : window.innerWidth) < 1024 ? "Drupal.gin.sidebarExpanded.mobile" : storageDesktop, showLabel = Drupal.t("Show sidebar panel"), sidebarTrigger = document.querySelector(".meta-sidebar__trigger");
+           null !== sidebarTrigger && (sidebarTrigger.querySelector("span").innerHTML = showLabel, 
+           sidebarTrigger.setAttribute("title", showLabel), sidebarTrigger.nextSibling && (sidebarTrigger.nextSibling.innerHTML = showLabel), 
+           sidebarTrigger.setAttribute("aria-expanded", "false"), sidebarTrigger.classList.remove("is-active"), 
+@@ -45,7 +45,7 @@
+         },
+         handleResize: function() {
+           let windowSize = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : window;
+-          Drupal.ginSidebar.removeInlineStyles(), windowSize.width < 1024 ? Drupal.ginSidebar.collapseSidebar() : "true" === localStorage.getItem(storageDesktop) ? Drupal.ginSidebar.showSidebar() : Drupal.ginSidebar.collapseSidebar();
++          Drupal.ginSidebar.removeInlineStyles(), windowSize.width < 1024 ? Drupal.ginSidebar.collapseSidebar(windowSize.width) : "true" === localStorage.getItem(storageDesktop) ? Drupal.ginSidebar.showSidebar(windowSize.width) : Drupal.ginSidebar.collapseSidebar(windowSize.width);
+         },
+         removeInlineStyles: () => {
+           const elementToRemove = document.querySelector(".gin-sidebar-inline-styles");
+diff --git a/js/sidebar.js b/js/sidebar.js
+index 5f01ec55..7c187a01 100644
+--- a/js/sidebar.js
++++ b/js/sidebar.js
+@@ -83,8 +83,8 @@
+       }
+     },
+ 
+-    showSidebar: () => {
+-      const chooseStorage = window.innerWidth < breakpoint ? storageMobile : storageDesktop;
++    showSidebar: (width = window.innerWidth) => {
++      const chooseStorage = width < breakpoint ? storageMobile : storageDesktop;
+       const hideLabel = Drupal.t('Hide sidebar panel');
+       const sidebarTrigger = document.querySelector('.meta-sidebar__trigger');
+       if (sidebarTrigger === null) {
+@@ -116,8 +116,8 @@
+       }
+     },
+ 
+-    collapseSidebar: () => {
+-      const chooseStorage = window.innerWidth < breakpoint ? storageMobile : storageDesktop;
++    collapseSidebar: (width = window.innerWidth) => {
++      const chooseStorage = width < breakpoint ? storageMobile : storageDesktop;
+       const showLabel = Drupal.t('Show sidebar panel');
+       const sidebarTrigger = document.querySelector('.meta-sidebar__trigger');
+       if (sidebarTrigger === null) {
+@@ -143,13 +143,13 @@
+ 
+       // If small viewport, always collapse sidebar.
+       if (windowSize.width < breakpoint) {
+-        Drupal.ginSidebar.collapseSidebar();
++        Drupal.ginSidebar.collapseSidebar(windowSize.width);
+       } else {
+         // If large viewport, show sidebar if it was open before.
+         if (localStorage.getItem(storageDesktop) === 'true') {
+-          Drupal.ginSidebar.showSidebar();
++          Drupal.ginSidebar.showSidebar(windowSize.width);
+         } else {
+-          Drupal.ginSidebar.collapseSidebar();
++          Drupal.ginSidebar.collapseSidebar(windowSize.width);
+         }
+       }
+     },


### PR DESCRIPTION
## Summary

Applies two patches from drupal.org issue [#3580451](https://www.drupal.org/project/gin/issues/3580451) to fix a Gin 5.0.12 bug where the admin node-edit sidebar disappears after a viewport resize through the narrow/wide breakpoint, with no way to recover short of clearing browser storage.

Root cause (confirmed by Gin maintainer yannickoo, comment #7):
- **JS storage-key race** in `dist/js/sidebar.js` — resize handler can write to the wrong localStorage key during a viewport transition, leaving the sidebar flagged collapsed at desktop widths.
- **Missing CSS selectors** in `dist/css/components/sidebar.css` — `.meta-sidebar__trigger` and its `::before` pseudo render at 0×0 px, so the recovery button is invisible.

Both patches (comment #6) are required; the maintainer has acknowledged them as a valid fix.

## Test plan

- [ ] CI green
- [ ] Multidev deploys cleanly
- [ ] On a node edit page, narrow the browser below 1024px and widen back: sidebar remains visible / recoverable
- [ ] Manually poisoning `localStorage["Drupal.gin.sidebarExpanded.desktop"] = "false"` and reloading: "Show sidebar panel" trigger is rendered at 32×32px (was 0×0 pre-patch) and clicking it restores the sidebar
