### PR TITLE
Add canonical GitHub Actions deploy workflows for Pantheon

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,68 @@
+# GitHub Actions deploy workflows for Pantheon
+
+This directory contains the EC canonical pattern for deploying Drupal sites to
+Pantheon via GitHub Actions. Validated on the `hmbweb` migration (2026-05-29).
+
+## What each workflow does
+
+| File | Trigger | Action |
+|---|---|---|
+| `deploy-main.yml` | push to `main` | Pushes to Pantheon's `dev` env (`master` branch on Pantheon's git), waits for build, runs `drush deploy`, clears edge cache |
+| `deploy-pr.yml` | PR opened or reopened | Creates a new Pantheon multidev named after the branch, runs `drush deploy` |
+| `deploy-pr-push.yml` | push to any non-`main` branch (only if PR is open) | Updates the existing multidev with new code, runs `drush deploy` |
+| `cleanup-pr.yml` | PR closed (merged or not) | Deletes the multidev (if it exists) and the Pantheon-side branch |
+
+Each workflow has a per-branch concurrency group so rapid commits don't race.
+`deploy-main` queues commits sequentially; PR workflows cancel-in-progress.
+
+## Required GitHub Action secrets
+
+| Secret | Source | Scope |
+|---|---|---|
+| `PANTHEON_SITE_NAME` | Pantheon machine name (e.g. `mysite`) | Per-repo |
+| `PANTHEON_REPO` | `terminus connection:info $SITE.dev --field=git_url` | Per-repo |
+| `KNOWN_HOSTS` | `ssh-keyscan -p 2222 -t rsa,ed25519 codeserver.dev.$UUID.drush.in` | Per-repo |
+| `PANTHEON_SSH_KEY` | RSA 4096 private key, registered with Pantheon via `terminus ssh-key:add` | Per-repo |
+| `SSH_CONFIG` | Static template (see below) | Can be org-level |
+| `PANTHEON_MACHINE_TOKEN` | A Pantheon machine token (`https://dashboard.pantheon.io/personal-settings/machine-tokens`) | Can be org-level |
+
+`SSH_CONFIG` contents:
+```
+Host *.drush.in
+  Port 2222
+  IdentityFile ~/.ssh/id_rsa
+  IdentitiesOnly yes
+  StrictHostKeyChecking yes
+  UserKnownHostsFile ~/.ssh/known_hosts
+```
+
+`PANTHEON_SSH_KEY` MUST be RSA 4096 (Pantheon rejects ed25519). Generate per-site
+so a single key compromise has limited blast radius.
+
+## The bootstrap-readiness poll (most important pattern)
+
+Each deploy workflow has a "Wait for Pantheon build_step to complete" step that
+polls `terminus drush $SITE.$ENV -- status --field=bootstrap` until it returns
+`Successful`. This is the canonical fix for Pantheon's `build_step: true` race
+condition where `terminus workflow:wait` returns before composer install
+finishes server-side. See the GOTCHAS in the `circle-to-gha-pantheon` Claude
+skill for the full investigation.
+
+If you remove the bootstrap poll, expect intermittent failures with:
+- "drush command 'deploy' not found"
+- Exit 137 (SIGKILL)
+- "Class Drupal\Core\Utility\Error not found" (autoloader fatal)
+
+All three symptoms have the same root cause and are all resolved by the poll.
+
+## Site requirements
+
+The workflows assume:
+- `pantheon.yml` has `build_step: true` (server-side composer install)
+- `.gitignore` excludes `/vendor`, `/web/core`, `/web/libraries`
+- Drush 10+ available via composer (for `drush deploy` command)
+
+## Related skills
+
+- **`circle-to-gha-pantheon`** — for migrating existing EC sites from CircleCI to these workflows
+- **`pantheon-spinup`** — for new sites; the workflows here land in the new site automatically via the scaffold

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -1,0 +1,35 @@
+name: Cleanup Multidev (Close PR)
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  delete_multidev:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.PANTHEON_SSH_KEY }}
+          config: ${{ secrets.SSH_CONFIG }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - name: Install Terminus
+        uses: pantheon-systems/terminus-github-actions@main
+        with:
+          pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+      - name: Delete Multidev
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          MULTIDEV=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-11 | sed 's/^-*//;s/-*$//')
+          if terminus env:list ${{ secrets.PANTHEON_SITE_NAME }} --format=list | grep -qx "$MULTIDEV"; then
+            echo "Deleting multidev: $MULTIDEV"
+            terminus multidev:delete ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV --delete-branch --yes
+          else
+            echo "Multidev '$MULTIDEV' does not exist on Pantheon — nothing to delete."
+          fi

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,62 @@
+name: Deploy to Pantheon (Main Branch)
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy_main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.PANTHEON_SSH_KEY }}
+          config: ${{ secrets.SSH_CONFIG }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - name: Install Terminus
+        uses: pantheon-systems/terminus-github-actions@main
+        with:
+          pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+      - name: Push code to Pantheon dev/master
+        run: |
+          terminus connection:set ${{ secrets.PANTHEON_SITE_NAME }}.dev git
+          git remote add pantheon "${{ secrets.PANTHEON_REPO }}"
+          git push --force pantheon HEAD:master
+          terminus workflow:wait ${{ secrets.PANTHEON_SITE_NAME }}.dev
+
+      - name: Wait for Pantheon build_step to complete
+        run: |
+          # workflow:wait above can return before Pantheon's server-side composer install
+          # finishes. Poll Drupal bootstrap directly — when it succeeds, the env is ready.
+          # Times out at 10 minutes (typical settle: 1-4 minutes).
+          for i in $(seq 1 60); do
+            if terminus drush ${{ secrets.PANTHEON_SITE_NAME }}.dev -- status --field=bootstrap 2>/dev/null | grep -q Successful; then
+              echo "Drupal bootstrap ready after ${i}0s"
+              exit 0
+            fi
+            echo "[${i}/60] Waiting for Drupal to be bootable..."
+            sleep 10
+          done
+          echo "ERROR: Drupal never became bootable within 10 minutes"
+          exit 1
+
+      - name: Run Drush updates
+        run: |
+          terminus env:wake ${{ secrets.PANTHEON_SITE_NAME }}.dev
+          terminus drush ${{ secrets.PANTHEON_SITE_NAME }}.dev -- deploy
+          terminus env:clear-cache ${{ secrets.PANTHEON_SITE_NAME }}.dev

--- a/.github/workflows/deploy-pr-push.yml
+++ b/.github/workflows/deploy-pr-push.yml
@@ -1,0 +1,98 @@
+name: Deploy to Pantheon (Push to PR)
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: deploy-push-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  update_multidev:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.PANTHEON_SSH_KEY }}
+          config: ${{ secrets.SSH_CONFIG }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - name: Check if this branch has an open PR
+        id: check_pr
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          REPO="${{ github.repository }}"
+
+          # Debugging: Print the repo and branch info
+          echo "Checking PRs for repository: $REPO"
+          echo "Looking for PRs with head branch: $BRANCH_NAME"
+          PR_COUNT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/$REPO/pulls?head=${{ github.repository_owner }}:$BRANCH_NAME" | jq '. | length')
+
+          echo "Found PR Count: $PR_COUNT"
+
+          if [ "$PR_COUNT" -gt 0 ]; then
+            echo "HAS_PR=true" >> $GITHUB_ENV
+          else
+            echo "HAS_PR=false" >> $GITHUB_ENV
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Terminus
+        if: env.HAS_PR == 'true'
+        uses: pantheon-systems/terminus-github-actions@main
+        with:
+          pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+      - name: Generate Multidev Name
+        if: env.HAS_PR == 'true'
+        id: multidev_name
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-11 | sed 's/^-*//;s/-*$//')
+          echo "multidev_env=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Push Updates to Multidev
+        if: env.HAS_PR == 'true'
+        run: |
+          MULTIDEV="${{ steps.multidev_name.outputs.multidev_env }}"
+          git remote add pantheon "${{ secrets.PANTHEON_REPO }}"
+          git push --force pantheon HEAD:refs/heads/$MULTIDEV
+          terminus workflow:wait ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV
+
+      - name: Wait for multidev build_step to complete
+        if: env.HAS_PR == 'true'
+        run: |
+          MULTIDEV="${{ steps.multidev_name.outputs.multidev_env }}"
+          # workflow:wait above can return before Pantheon's server-side composer install
+          # finishes. Poll Drupal bootstrap directly (typical 1-4 min, 10 min cap).
+          for i in $(seq 1 60); do
+            if terminus drush ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV -- status --field=bootstrap 2>/dev/null | grep -q Successful; then
+              echo "Drupal bootstrap ready after ${i}0s"
+              exit 0
+            fi
+            echo "[${i}/60] Waiting for Drupal to be bootable on $MULTIDEV..."
+            sleep 10
+          done
+          echo "ERROR: Drupal never became bootable within 10 minutes"
+          exit 1
+
+      - name: Run Drush on Multidev
+        if: env.HAS_PR == 'true'
+        run: |
+          MULTIDEV="${{ steps.multidev_name.outputs.multidev_env }}"
+          terminus env:wake ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV
+          terminus drush ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV -- deploy
+          terminus env:clear-cache ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,0 +1,73 @@
+name: Deploy to Pantheon (Open new PR)
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-pr-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  create_multidev:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.PANTHEON_SSH_KEY }}
+          config: ${{ secrets.SSH_CONFIG }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - name: Install Terminus
+        uses: pantheon-systems/terminus-github-actions@main
+        with:
+          pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+      - name: Generate Multidev Name
+        id: multidev_name
+        run: |
+          BRANCH_NAME="${{ github.head_ref }}"
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-11 | sed 's/^-*//;s/-*$//')
+          echo "multidev_env=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Push to Multidev
+        run: |
+          MULTIDEV="${{ steps.multidev_name.outputs.multidev_env }}"
+          git remote add pantheon "${{ secrets.PANTHEON_REPO }}"
+          # Push the branch to Pantheon. Pantheon will NOT trigger a "Sync code" workflow
+          # for branches that have no multidev yet — it just receives the branch. The
+          # multidev:create call below is what actually provisions the env.
+          git push --force pantheon HEAD:refs/heads/$MULTIDEV
+          terminus multidev:create ${{ secrets.PANTHEON_SITE_NAME }}.dev "$MULTIDEV"
+
+      - name: Wait for multidev build_step to complete
+        run: |
+          MULTIDEV="${{ steps.multidev_name.outputs.multidev_env }}"
+          # multidev:create triggers Pantheon's env-creation workflow, which terminus
+          # auto-waits for — but build_step composer install may still be settling.
+          # Poll Drupal bootstrap directly until ready (typical 1-4 min, 10 min cap).
+          for i in $(seq 1 60); do
+            if terminus drush ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV -- status --field=bootstrap 2>/dev/null | grep -q Successful; then
+              echo "Drupal bootstrap ready after ${i}0s"
+              exit 0
+            fi
+            echo "[${i}/60] Waiting for Drupal to be bootable on $MULTIDEV..."
+            sleep 10
+          done
+          echo "ERROR: Drupal never became bootable within 10 minutes"
+          exit 1
+
+      - name: Run Drush on Multidev
+        run: |
+          MULTIDEV="${{ steps.multidev_name.outputs.multidev_env }}"
+          terminus env:wake ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV
+          terminus drush ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV -- deploy
+          terminus env:clear-cache ${{ secrets.PANTHEON_SITE_NAME }}.$MULTIDEV


### PR DESCRIPTION
## Summary

Adds the EC canonical 4-workflow set for deploying Drupal sites to Pantheon via GitHub Actions, plus a colocated `README.md` documenting the required secrets and the bootstrap-poll pattern that makes the `build_step: true` race robust.

Before this PR, ec-upstream had no `.github/workflows/`. Sites derived from ec-upstream had to either keep using CircleCI or hand-copy GH Actions workflows from `ec2025`. After this PR, new sites get the proven pattern out of the box.

## What's included

```
.github/workflows/
  deploy-main.yml       — push to main → Pantheon dev → drush deploy
  deploy-pr.yml         — PR opened → create multidev → drush deploy
  deploy-pr-push.yml    — push to PR branch → update multidev → drush deploy
  cleanup-pr.yml        — PR closed → delete multidev (guarded)
  README.md             — required secrets, bootstrap-poll rationale, site requirements
```

## Provenance and validation

This is NOT a verbatim copy of the ec2025 workflows. It's the iteratively refined version validated end-to-end during the `hmbweb` Circle→GH-Actions migration (electriccitizen/hmbweb PRs #279, #280, #281).

The ec2025 workflows had several latent bugs that surfaced during real-world migration:

| Bug | Symptom | Fix in this version |
|---|---|---|
| `cut -c1-11` on branch name leaves trailing `-` for some names | Multidev push rejected by Pantheon; cryptic "bad line length character" | `sed 's/^-*//;s/-*$//'` strip after truncate |
| Duplicate `actions/checkout@v4` in deploy-pr-push.yml | ~10s wasted on every run | Removed redundant step |
| `cleanup-pr.yml` unconditionally deletes multidev | Fails noisily when PR closed without ever creating a multidev | Guard with `terminus env:list` check |
| `terminus workflow:wait` returns before Pantheon's build_step finishes | "drush command not found", exit 137 SIGKILL, autoloader fatals — all intermittent | **Bootstrap-readiness poll** — `terminus drush -- status --field=bootstrap` in a loop until "Successful" |
| `::set-output` deprecated by GitHub | Will eventually break | Use `$GITHUB_OUTPUT` |
| No `permissions:` blocks | Workflows default to full write | Explicit minimums: `contents: read`, `pull-requests: read` where needed |
| No `concurrency:` control | Rapid commits race each other | Per-branch concurrency; cancel-in-progress for PRs, queued for main |
| No `timeout-minutes:` | Default is 6h; hung deploys waste runner minutes | 30min for deploys, 10min for cleanup |

The bootstrap-poll fix is the most important — it's what makes deploys reliable on the first attempt instead of requiring reruns.

## What's NOT included (deferred)

These are worth doing but are separate decisions:

- **Action SHA pinning + dependabot** — major versions (`@v4`, `@v2`, `@main`) are mutable refs. Want SHA-pinning for supply-chain hygiene, but that's a full setup (dependabot config, regular bump reviews) worth its own PR.
- **Bump action major versions for Node 24 compat** — `actions/checkout@v4` + `shimataro/ssh-key-action@v2` warn about Node 20 deprecation (forced June 2026). Need to validate v5 / v3 don't change behavior subtly.
- **Failure notifications** — `if: failure()` Slack/email step. Needs EC-wide design (channel, format, bot creds).
- **Reconcile with ec2025** — `ec2025` still has the older buggy versions. Should probably get the same fixes applied (separate PR) until ec2025/ec-upstream consolidation is decided.

## Setup required when applying to a site

See `.github/workflows/README.md` for full details. Summary:

1. Generate RSA 4096 deploy keypair, register with Pantheon (`terminus ssh-key:add`)
2. Set 6 GH Action secrets (`PANTHEON_*`, `SSH_*`, `KNOWN_HOSTS`) — see README
3. Verify `pantheon.yml` has `build_step: true`
4. Verify `.gitignore` excludes `/vendor`, `/web/core`, `/web/libraries`

For migrating an existing CircleCI-based site, use the `circle-to-gha-pantheon` Claude skill — it walks through the full process.

## Test plan

- [ ] Spin up a new test site from ec-upstream (or apply to an existing ec-upstream-derived site)
- [ ] Set the 6 secrets per the README
- [ ] Push a trivial commit → confirm `deploy-main` completes cleanly first try
- [ ] Open a PR → confirm `deploy-pr` creates multidev, deploys, no rerun needed
- [ ] Push to that PR → confirm `deploy-pr-push` updates multidev
- [ ] Close the PR → confirm `cleanup-pr` deletes the multidev cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)